### PR TITLE
Moved functions to base class

### DIFF
--- a/include/verification-algorithms/common/verifier.hpp
+++ b/include/verification-algorithms/common/verifier.hpp
@@ -8,6 +8,18 @@ class Verifier {
   public:
 
     virtual bool check(std::string) = 0;
-    virtual int getLength() = 0;
-    virtual Trace getTrace() = 0;
+    virtual inline int getLength(){
+      return stoppedAt;    
+    };
+    virtual inline Trace getTrace(){
+      if(result) throw std::logic_error("No Trace. Last result was SAT");
+      return trace;
+    };
+
+  protected:
+
+    Trace trace;
+
+    bool result;
+    int stoppedAt;
 };

--- a/include/verification-algorithms/ic3/ic3.hpp
+++ b/include/verification-algorithms/ic3/ic3.hpp
@@ -25,9 +25,6 @@ class IC3 : public Verifier {
     inline z3::expr getT() { return T; }
     inline z3::expr getP() { return P; }
 
-    inline int getLength() override { return stoppedAt; }
-    inline Trace getTrace() override { assert(result == false); return trace;  }
-
   private:
 
     void declare();
@@ -39,10 +36,6 @@ class IC3 : public Verifier {
     z3::expr_vector x;
     z3::expr_vector next_x;
 
-    Trace trace;
-
-    int stoppedAt;
-    bool result;
     std::vector<Symbol> symbols;
     std::vector<CNF> frames;
 };

--- a/include/verification-algorithms/k-induction/k-induction.hpp
+++ b/include/verification-algorithms/k-induction/k-induction.hpp
@@ -28,9 +28,6 @@ class kInduction : public Verifier {
     inline z3::expr getT() { return T; }
     inline z3::expr getP() { return P; }
 
-    inline int  getLength() override { return stoppedAt; }
-    inline Trace getTrace() override { assert(result == false); return trace; }
-
     inline void setBound(int bound) { this->bound = bound;  }
     inline int getBound() { return bound; }
 
@@ -51,12 +48,8 @@ class kInduction : public Verifier {
     z3::expr P;
     z3::expr_vector x, next_x;
 
-    Trace trace;
-
-    int stoppedAt;
     int varsPerState;
     int bound{INT_MAX};
-    bool result;
     std::vector<Symbol> symbols;
     std::vector<z3::expr_vector> globalStates;
 

--- a/include/verification-algorithms/ltl-bmc/ltl-bmc.hpp
+++ b/include/verification-algorithms/ltl-bmc/ltl-bmc.hpp
@@ -27,9 +27,6 @@ class ltlBmc : public Verifier {
     inline z3::expr getI() { return I; }
     inline z3::expr getT() { return T; }
 
-    inline int  getLength() override { return stoppedAt; }
-    inline Trace getTrace() override { assert(result == false); return trace; }
-
     inline void setBound(int bound) { this->bound = bound;  }
     inline int getBound() { return bound; }
 
@@ -61,13 +58,9 @@ class ltlBmc : public Verifier {
     z3::expr I, T;
     z3::expr_vector x, next_x;
 
-    Trace trace;
-
     std::vector<Symbol> symbols;
 
     int varsPerState;
-    int stoppedAt;
     int bound;
-    bool result;
     std::vector<z3::expr_vector> globalStates;
 };


### PR DESCRIPTION
* Moved both ```getTrace()``` and ```getLength()``` to the base class and made the respective variables protected to reduce repeated code lines.
* Made ```getTrace()``` throw an error instead of ```assert``` if the previous result was **SAT**.